### PR TITLE
[refactor] 검색 키워드 빈 문자열 검사 공통 함수 분리 & 사용자 정보 수정 공통 컴포넌트 분리

### DIFF
--- a/src/components/setting/UpdateProfile.tsx
+++ b/src/components/setting/UpdateProfile.tsx
@@ -1,0 +1,243 @@
+import React, {useEffect, useState} from 'react';
+import styled from 'styled-components/native';
+import {
+  fontPercentage as fp,
+  widthPercentage as wp,
+  heightPercentage as hp,
+} from '~/components/common/ResponsiveSize';
+import {useNavigation} from '@react-navigation/native';
+import {RootStackNavigationProp} from '~/App';
+import BackView from '~/components/common/BackView';
+import {GoogleIcon, KakaoIcon, NaverIcon} from '~/assets/images';
+import ImageResizer from '@bam.tech/react-native-image-resizer';
+import {TouchableOpacity} from 'react-native';
+import {useUpdateUserInfo} from '~/api/queries/auth';
+import {showToast} from '~/components/common/modal/toastConfig';
+import LoadingModal from '~/components/common/modal/LoadingModal';
+import EditNickname from '~/screens/setting/updateProfile/EditNickname';
+import EditArtCategory from '~/screens/setting/updateProfile/EditArtCategory';
+import EditPicture from '~/screens/setting/updateProfile/EditPicture';
+
+type InitProfile = {
+  favoriteArt: string;
+  nickname: string;
+  profile: string | undefined;
+  email: string;
+  providerType: string;
+};
+
+type UpdateProfileMessage = {
+  errorMsg: string;
+  successMsg: string;
+};
+
+interface UpdateProfileProps {
+  title: string;
+  initProfile: InitProfile;
+  messages: UpdateProfileMessage;
+  navigateTo: string;
+}
+
+const UpdateProfile: React.FC<UpdateProfileProps> = ({
+  title,
+  initProfile,
+  messages,
+  navigateTo,
+}) => {
+  const navigation = useNavigation<RootStackNavigationProp>();
+  const [art, setArt] = useState<string>(initProfile.favoriteArt);
+  const [nicknameKeyword, setNicknameKeyword] = useState<string>(
+    initProfile.nickname,
+  );
+  const [imageUri, setImageUri] = useState<string | undefined>(
+    initProfile.profile
+      ? `data:image/png;base64,${initProfile.profile}`
+      : initProfile.profile,
+  );
+  const [createFormData, setCreateFormData] = useState<FormData | null>(null);
+  const [isVerified, setIsVerified] = useState<boolean>(false);
+  const [isLoadingOpen, setIsLoadingOpen] = useState<boolean>(false);
+  const {
+    mutate: updateUserInfo,
+    isLoading,
+    isError,
+    isSuccess,
+  } = useUpdateUserInfo(createFormData);
+
+  useEffect(() => {
+    if (createFormData !== null) {
+      updateUserInfo();
+    }
+  }, [createFormData]);
+
+  useEffect(() => {
+    if (isError) {
+      showToast(messages.errorMsg);
+    }
+    if (isLoading) {
+      setIsLoadingOpen(true);
+    }
+    if (!isLoading) {
+      setIsLoadingOpen(false);
+    }
+    if (isSuccess) {
+      setCreateFormData(null);
+      showToast(messages.successMsg);
+      if (navigateTo === 'back') {
+        navigation.goBack();
+      } else if (navigateTo === 'Main') {
+        navigation.navigate('Main');
+      }
+    }
+  }, [isError, isLoading, isSuccess]);
+
+  const onPressComplete = async () => {
+    const formData = new FormData();
+
+    formData.append('nickname', nicknameKeyword);
+    formData.append('favoriteArt', art);
+
+    const isImage = imageUri?.search('file://');
+    if (isImage && isImage !== -1) {
+      const resizedImage = await ImageResizer.createResizedImage(
+        imageUri ?? '', // path
+        300, // width
+        300, // height
+        'JPEG', // format
+        100, // quality
+        undefined, // rotation
+        // uploadFileName, // outputPath
+        undefined, // keepMeta,
+        undefined, // options => object
+      );
+      const uri = resizedImage.uri;
+      const filename = uri.split('/').pop();
+      const match = /\.(\w+)$/.exec(filename || '');
+      const type = match ? `image/${match[1]}` : `image`;
+
+      formData.append('profile', {
+        name: filename,
+        type,
+        uri: uri,
+      });
+    }
+    setCreateFormData(formData);
+  };
+
+  return (
+    <Container>
+      <BackView title={title} line={true} />
+
+      {/* body */}
+      <Contents>
+        {/* 닉네임 */}
+        <EditNickname
+          getNickname={nicknameKeyword}
+          setNickname={setNicknameKeyword}
+          isVerified={isVerified}
+          setIsVerified={setIsVerified}
+        />
+        {/* 좋아하는 전시 분야 */}
+        <EditArtCategory getValue={art} setValue={setArt} />
+        {/* 프로필 */}
+        <EditPicture imageUri={imageUri} setImageUri={setImageUri} />
+        {/* 이메일 */}
+        <ContentColumn>
+          <SectionName>이메일</SectionName>
+          <BoxView color={true}>
+            {initProfile.providerType === 'naver' ? (
+              <NaverIcon width={20} />
+            ) : initProfile.providerType === 'gmail' ||
+              initProfile.providerType === 'google' ? (
+              <GoogleIcon width={20} />
+            ) : (
+              <KakaoIcon width={20} />
+            )}
+            <EmailText>{initProfile.email}</EmailText>
+          </BoxView>
+        </ContentColumn>
+        {/* 완료 버튼 */}
+        <TouchableOpacity
+          disabled={!(nicknameKeyword !== '' && art !== '' && isVerified)}
+          onPress={onPressComplete}>
+          <CompleteButton
+            complete={nicknameKeyword !== '' && art !== '' && isVerified}>
+            {/* 중복 확인 완료도 검사 */}
+            완료
+          </CompleteButton>
+        </TouchableOpacity>
+      </Contents>
+      {isLoadingOpen && <LoadingModal message={'정보 수정 중 :)'} />}
+    </Container>
+  );
+};
+
+export default UpdateProfile;
+
+/** style */
+const Container = styled.View`
+  flex: 1;
+`;
+
+const Contents = styled.View`
+  flex: 1;
+  width: 100%;
+  height: 100%;
+  flex-direction: column;
+  background-color: #f6f6f6;
+  padding-left: ${wp(15)}px;
+  padding-right: ${wp(15)}px;
+  padding-top: ${hp(10)}px;
+  padding-bottom: ${hp(10)}px;
+  gap: ${hp(15)}px;
+`;
+
+const ContentColumn = styled.View`
+  flex-direction: column;
+  width: 100%;
+  gap: ${hp(10)}px;
+`;
+
+const SectionName = styled.Text`
+  font-size: ${fp(19)}px;
+  color: #3c4045;
+  font-family: 'omyu pretty';
+`;
+
+interface ContentProps {
+  color: boolean;
+}
+
+const BoxView = styled.View<ContentProps>`
+  border-width: 1.5px;
+  border-color: #d3d3d3;
+  border-radius: 10px;
+  flex-direction: row;
+  background-color: ${(props: ContentProps) =>
+    props.color ? '#d9d9d9' : '#f6f6f6'};
+  padding: ${hp(10)}px;
+  gap: 6.5px;
+  align-items: center;
+`;
+
+const EmailText = styled.Text`
+  font-size: ${fp(18)}px;
+  color: white;
+  font-family: 'omyu pretty';
+  text-align: center;
+`;
+
+interface CompleteButtonProps {
+  complete: boolean;
+}
+
+const CompleteButton = styled.Text<CompleteButtonProps>`
+  padding: ${hp(10)}px;
+  border-radius: 5px;
+  text-align: center;
+  background-color: ${(props: CompleteButtonProps) =>
+    props.complete ? '#ff6f61' : '#D3D3D3'};
+  color: white;
+  font-size: ${fp(17)}px;
+  font-family: 'omyu pretty';
+`;

--- a/src/screens/exhibition/ExhSearchName.tsx
+++ b/src/screens/exhibition/ExhSearchName.tsx
@@ -13,6 +13,7 @@ import {showToast} from '~/components/common/modal/toastConfig';
 import {useNavigation} from '@react-navigation/native';
 import {RootStackNavigationProp} from '~/App';
 import {useSearchNameActions} from '~/zustand/exhibition/exhibition';
+import {checkBlankInKeyword} from '~/utils/CheckKeyword';
 
 const ExhSearchName = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
@@ -23,7 +24,7 @@ const ExhSearchName = () => {
   const examples: string[] = ['요시다유니', '장욱진', '덕수궁']; //search_list에서 가져올 것.
 
   const onPressSearch = (name: string) => {
-    if (checkKeyword(searchKeyword)) {
+    if (checkBlankInKeyword(searchKeyword)) {
       showToast('다시 검색해 주세요');
     } else {
       setKeyword(searchKeyword);
@@ -33,17 +34,6 @@ const ExhSearchName = () => {
       navigation.goBack();
     }
     Keyboard.dismiss();
-  };
-
-  const checkKeyword = (text: string): boolean => {
-    var blank = false;
-    if (text === '') {
-      blank = true;
-    }
-    if (text.trim() === '') {
-      blank = true;
-    }
-    return blank;
   };
 
   const onPressPreSearch = (text: string) => {

--- a/src/screens/login/InitProfileScreen.tsx
+++ b/src/screens/login/InitProfileScreen.tsx
@@ -1,203 +1,27 @@
-import React, {useEffect, useState} from 'react';
-import styled from 'styled-components/native';
-import {
-  fontPercentage as fp,
-  widthPercentage as wp,
-  heightPercentage as hp,
-} from '~/components/common/ResponsiveSize';
-import {useNavigation} from '@react-navigation/native';
-import {RootStackNavigationProp} from '~/App';
-import BackView from '~/components/common/BackView';
-import {GoogleIcon, KakaoIcon, NaverIcon} from '~/assets/images';
-import ImageResizer from '@bam.tech/react-native-image-resizer';
-import {TouchableOpacity} from 'react-native';
-import {useUpdateUserInfo} from '~/api/queries/auth';
-import {showToast} from '~/components/common/modal/toastConfig';
-import LoadingModal from '~/components/common/modal/LoadingModal';
-import EditNickname from '../setting/updateProfile/EditNickname';
-import EditArtCategory from '../setting/updateProfile/EditArtCategory';
-import EditPicture from '../setting/updateProfile/EditPicture';
+import React from 'react';
 import {useUserLoginInfo} from '~/zustand/auth/authLogin';
+import UpdateProfile from '~/components/setting/UpdateProfile';
 
 const InitProfileScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
-  const [art, setArt] = useState<string>('');
-  const [nicknameKeyword, setNicknameKeyword] = useState<string>('');
-  const [imageUri, setImageUri] = useState<string | undefined>(undefined);
-  const [createFormData, setCreateFormData] = useState<FormData | null>(null);
-  const [isLoadingOpen, setIsLoadingOpen] = useState<boolean>(false);
   const userloginInfo = useUserLoginInfo();
-  const {
-    mutate: updateUserInfo,
-    isLoading,
-    isError,
-    isSuccess,
-  } = useUpdateUserInfo(createFormData);
-
-  useEffect(() => {
-    if (createFormData !== null) {
-      updateUserInfo();
-    }
-  }, [createFormData]);
-
-  useEffect(() => {
-    if (isError) {
-      showToast('정보 초기화를 실패했습니다.');
-    }
-    if (isLoading) {
-      setIsLoadingOpen(true);
-    }
-    if (!isLoading) {
-      setIsLoadingOpen(false);
-    }
-    if (isSuccess) {
-      setCreateFormData(null);
-      showToast('정보 초기화 완료!');
-      navigation.navigate('Main');
-    }
-  }, [isError, isLoading, isSuccess]);
-
-  const onPressComplete = async () => {
-    const formData = new FormData();
-
-    formData.append('nickname', nicknameKeyword);
-    formData.append('favoriteArt', art);
-    const isImage = imageUri?.search('file://');
-    if (isImage && isImage !== -1) {
-      const resizedImage = await ImageResizer.createResizedImage(
-        imageUri ?? '', // path
-        300, // width
-        300, // height
-        'JPEG', // format
-        100, // quality
-        undefined, // rotation
-        // uploadFileName, // outputPath
-        undefined, // keepMeta,
-        undefined, // options => object
-      );
-      const uri = resizedImage.uri;
-      const filename = uri.split('/').pop();
-      const match = /\.(\w+)$/.exec(filename || '');
-      const type = match ? `image/${match[1]}` : `image`;
-
-      formData.append('profile', {
-        name: filename,
-        type,
-        uri: uri,
-      });
-    }
-    setCreateFormData(formData);
-  };
 
   return (
-    <Container>
-      <BackView title="프로필 수정" line={true} />
-
-      {/* body */}
-      <Contents>
-        {/* 닉네임 */}
-        <EditNickname
-          getNickname={nicknameKeyword}
-          setNickname={setNicknameKeyword}
-        />
-        {/* 좋아하는 전시 분야 */}
-        <EditArtCategory getValue={art} setValue={setArt} />
-        {/* 프로필 */}
-        <EditPicture imageUri={imageUri} setImageUri={setImageUri} />
-        {/* 이메일 */}
-        <ContentColumn>
-          <SectionName>이메일</SectionName>
-          <BoxView color={true}>
-            {userloginInfo.providerType === 'naver' ? (
-              <NaverIcon width={20} />
-            ) : userloginInfo.providerType === 'gmail' ? (
-              <GoogleIcon width={20} />
-            ) : (
-              <KakaoIcon width={20} />
-            )}
-            <EmailText>{userloginInfo.email}</EmailText>
-          </BoxView>
-        </ContentColumn>
-        {/* 완료 버튼 */}
-        <TouchableOpacity
-          disabled={!(nicknameKeyword !== '' && art !== '')}
-          onPress={onPressComplete}>
-          <CompleteButton complete={nicknameKeyword !== '' && art !== ''}>
-            완료
-          </CompleteButton>
-        </TouchableOpacity>
-      </Contents>
-      {isLoadingOpen && <LoadingModal message={'정보 수정 중 :)'} />}
-    </Container>
+    <UpdateProfile
+      title={'프로필 초기화'}
+      initProfile={{
+        favoriteArt: '',
+        nickname: '',
+        profile: undefined,
+        email: userloginInfo.email,
+        providerType: userloginInfo.providerType,
+      }}
+      messages={{
+        errorMsg: '정보 초기화를 실패했습니다.',
+        successMsg: '정보 초기화 완료!',
+      }}
+      navigateTo={'Main'}
+    />
   );
 };
 
 export default InitProfileScreen;
-
-/** style */
-const Container = styled.View`
-  flex: 1;
-`;
-
-const Contents = styled.View`
-  flex: 1;
-  width: 100%;
-  height: 100%;
-  flex-direction: column;
-  background-color: #f6f6f6;
-  padding-left: ${wp(15)}px;
-  padding-right: ${wp(15)}px;
-  padding-top: ${hp(10)}px;
-  padding-bottom: ${hp(10)}px;
-  gap: ${hp(15)}px;
-`;
-
-const ContentColumn = styled.View`
-  flex-direction: column;
-  width: 100%;
-  gap: ${hp(10)}px;
-`;
-
-const SectionName = styled.Text`
-  font-size: ${fp(19)}px;
-  color: #3c4045;
-  font-family: 'omyu pretty';
-`;
-
-interface ContentProps {
-  color: boolean;
-}
-
-const BoxView = styled.View<ContentProps>`
-  border-width: 1.5px;
-  border-color: #d3d3d3;
-  border-radius: 10px;
-  flex-direction: row;
-  background-color: ${(props: ContentProps) =>
-    props.color ? '#d9d9d9' : '#f6f6f6'};
-  padding: ${hp(10)}px;
-  gap: 6.5px;
-  align-items: center;
-`;
-
-const EmailText = styled.Text`
-  font-size: ${fp(18)}px;
-  color: white;
-  font-family: 'omyu pretty';
-  text-align: center;
-`;
-
-interface NextButtonProps {
-  complete: boolean;
-}
-
-const CompleteButton = styled.Text<NextButtonProps>`
-  padding: ${hp(10)}px;
-  border-radius: 5px;
-  text-align: center;
-  background-color: ${(props: NextButtonProps) =>
-    props.complete ? '#ff6f61' : '#D3D3D3'};
-  color: white;
-  font-size: ${fp(17)}px;
-  font-family: 'omyu pretty';
-`;

--- a/src/screens/login/LoginScreen.tsx
+++ b/src/screens/login/LoginScreen.tsx
@@ -99,7 +99,6 @@ const LoginScreen = () => {
         providerId: loginUserInfo.providerId,
       });
       setIsLoadingOpen(false);
-      navigation.navigate('InitProfile');
     }
   };
 

--- a/src/screens/mate/AddNewMateScreen.tsx
+++ b/src/screens/mate/AddNewMateScreen.tsx
@@ -14,6 +14,7 @@ import LoadingModal from '~/components/common/modal/LoadingModal';
 import SearchExhFrame from '~/components/exhSearch/SearchExhFrame';
 import SearchNewMateList from './SearchNewMateList';
 import {useAddNewMate} from '~/api/queries/mate';
+import {checkBlankInKeyword} from '~/utils/CheckKeyword';
 
 const AddNewMateScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
@@ -54,19 +55,8 @@ const AddNewMateScreen = () => {
     }
   };
 
-  const checkKeyword = (text: string): boolean => {
-    var blank = false;
-    if (text === '') {
-      blank = true;
-    }
-    if (text.trim() === '') {
-      blank = true;
-    }
-    return blank;
-  };
-
   const onPressSearch = () => {
-    if (checkKeyword(nicknameKeyword)) {
+    if (checkBlankInKeyword(nicknameKeyword)) {
       showToast('다시 검색해 주세요');
     } else {
       setSelectedMate(-1);

--- a/src/screens/mydiary/MyExhSearchScreen.tsx
+++ b/src/screens/mydiary/MyExhSearchScreen.tsx
@@ -5,29 +5,19 @@ import BackView from '~/components/common/BackView';
 import SearchExhList from './SearchExhList';
 import {showToast} from '~/components/common/modal/toastConfig';
 import SearchExhFrame from '~/components/exhSearch/SearchExhFrame';
+import {checkBlankInKeyword} from '~/utils/CheckKeyword';
 
 const MyExhSearchScreen = () => {
   const [searchKeyword, setSearchKeyword] = useState<string>('');
   const [keyword, setKeyword] = useState<string>('');
 
   const onPressSearch = () => {
-    if (checkKeyword(searchKeyword)) {
+    if (checkBlankInKeyword(searchKeyword)) {
       showToast('다시 검색해 주세요');
     } else {
       setKeyword(searchKeyword);
     }
     Keyboard.dismiss();
-  };
-
-  const checkKeyword = (text: string): boolean => {
-    var blank = false;
-    if (text === '') {
-      blank = true;
-    }
-    if (text.trim() === '') {
-      blank = true;
-    }
-    return blank;
   };
 
   return (

--- a/src/screens/mydiary/writeDiary/WriteMyDiaryContentsScreen.tsx
+++ b/src/screens/mydiary/writeDiary/WriteMyDiaryContentsScreen.tsx
@@ -20,6 +20,7 @@ import LoadingModal from '~/components/common/modal/LoadingModal';
 import ImageResizer from '@bam.tech/react-native-image-resizer';
 import {useVisitedExhIdInfo} from '~/zustand/mydiary/mydiary';
 import {useTabIdentifierInfo} from '~/zustand/tabIdentifier';
+import {checkBlankInKeyword} from '~/utils/CheckKeyword';
 
 const WriteMyDiaryContentsScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
@@ -156,17 +157,6 @@ const WriteMyDiaryContentsScreen = () => {
     setContentsKeyword(text);
   }, []);
 
-  const checkKeyword = (text: string): boolean => {
-    var blank = false;
-    if (text === '') {
-      blank = true;
-    }
-    if (text.trim() === '') {
-      blank = true;
-    }
-    return blank;
-  };
-
   return (
     <Container>
       <BackView title="기록 작성" line={true} children={null} />
@@ -181,7 +171,7 @@ const WriteMyDiaryContentsScreen = () => {
             align={'center'}
           />
         </ScrollContents>
-        {!checkKeyword(contentsKeyword) ? (
+        {!checkBlankInKeyword(contentsKeyword) ? (
           <TouchableOpacity onPress={onClickNextButton}>
             <NextButton moveNext={true}>완료</NextButton>
           </TouchableOpacity>

--- a/src/screens/mydiary/writeDiary/WriteMyDiaryInfoScreen.tsx
+++ b/src/screens/mydiary/writeDiary/WriteMyDiaryInfoScreen.tsx
@@ -26,6 +26,7 @@ import {
   useWriteMyDiaryInfo,
 } from '~/zustand/mydiary/writeMyDiary';
 import {RootStackNavigationProp} from '~/App';
+import {checkBlankInKeyword} from '~/utils/CheckKeyword';
 
 const WriteMyDiaryInfoScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
@@ -107,17 +108,6 @@ const WriteMyDiaryInfoScreen = () => {
   const onChangeSaying = useCallback((text: string) => {
     setSayingKeyword(text);
   }, []);
-
-  const checkKeyword = (text: string): boolean => {
-    var blank = false;
-    if (text === '') {
-      blank = true;
-    }
-    if (text.trim() === '') {
-      blank = true;
-    }
-    return blank;
-  };
 
   const onClickNextButton = async () => {
     const today = new Date();
@@ -221,7 +211,7 @@ const WriteMyDiaryInfoScreen = () => {
           </PutThumbnail>
         </ThumbnailSection>
         {/* 다음 버튼 */}
-        {!checkKeyword(titleKeyword) &&
+        {!checkBlankInKeyword(titleKeyword) &&
         starNum > 0 &&
         imageUri !== undefined ? (
           <TouchableOpacity onPress={onClickNextButton}>

--- a/src/screens/setting/LeaveScreen.tsx
+++ b/src/screens/setting/LeaveScreen.tsx
@@ -10,8 +10,11 @@ import LoadingModal from '~/components/common/modal/LoadingModal';
 import {TouchableOpacity} from 'react-native';
 import {useDeleteUser} from '~/api/queries/auth';
 import {showToast} from '~/components/common/modal/toastConfig';
+import {useNavigation} from '@react-navigation/native';
+import {RootStackNavigationProp} from '~/App';
 
 const LeaveScreen = () => {
+  const navigation = useNavigation<RootStackNavigationProp>();
   const [isLoadingOpen, setIsLoadingOpen] = useState<boolean>(false);
   const [reasonKeyword, setReasonKeyword] = useState<string>('');
   const {
@@ -33,7 +36,11 @@ const LeaveScreen = () => {
     }
     if (isSuccess) {
       showToast('탈퇴 성공 :(');
-      // TODO 로그인 페이지로 이동
+      // 로그인 페이지로 이동
+      navigation.reset({
+        index: 0,
+        routes: [{name: 'Login'}],
+      });
     }
   }, [isError, isLoading, isSuccess]);
 

--- a/src/screens/setting/updateProfile/EditNickname.tsx
+++ b/src/screens/setting/updateProfile/EditNickname.tsx
@@ -6,18 +6,22 @@ import {
   widthPercentage as wp,
   heightPercentage as hp,
 } from '~/components/common/ResponsiveSize';
+import {checkBlankInKeyword} from '~/utils/CheckKeyword';
 import {useUserInfo} from '~/zustand/auth/auth';
 
 interface EditNicknameProps {
   getNickname: string;
   setNickname: (nickname: string) => void;
+  setIsVerified: (isVerified: boolean) => void;
+  isVerified: boolean;
 }
 
 const EditNickname: React.FC<EditNicknameProps> = ({
   getNickname,
   setNickname,
+  setIsVerified,
+  isVerified,
 }) => {
-  const [isVerified, setIsVerified] = useState<boolean>(false);
   const userInfo = useUserInfo();
   const {
     mutate: verifyNickname,
@@ -32,6 +36,7 @@ const EditNickname: React.FC<EditNicknameProps> = ({
   const onChangeNickname = useCallback((text: string) => {
     setNickname(text);
     setIsVerified(false);
+    setMessage(null);
   }, []);
 
   useEffect(() => {
@@ -55,7 +60,13 @@ const EditNickname: React.FC<EditNicknameProps> = ({
   }, [isError, isLoading, isSuccess]);
 
   const onPressVerify = () => {
-    verifyNickname();
+    // check nickname
+    if (checkBlankInKeyword(getNickname)) {
+      setMessage(' 닉네임을 작성해주세요.');
+      setMessageColor('#FF6F61');
+    } else {
+      verifyNickname();
+    }
   };
 
   return (

--- a/src/screens/setting/updateProfile/EditProfileScreen.tsx
+++ b/src/screens/setting/updateProfile/EditProfileScreen.tsx
@@ -1,205 +1,27 @@
-import React, {useEffect, useState} from 'react';
-import styled from 'styled-components/native';
-import {
-  fontPercentage as fp,
-  widthPercentage as wp,
-  heightPercentage as hp,
-} from '~/components/common/ResponsiveSize';
-import {useNavigation} from '@react-navigation/native';
-import {RootStackNavigationProp} from '~/App';
-import BackView from '~/components/common/BackView';
+import React from 'react';
 import {useUserInfo} from '~/zustand/auth/auth';
-import {GoogleIcon, KakaoIcon, NaverIcon} from '~/assets/images';
-import EditNickname from './EditNickname';
-import EditArtCategory from './EditArtCategory';
-import EditPicture from './EditPicture';
-import ImageResizer from '@bam.tech/react-native-image-resizer';
-import {TouchableOpacity} from 'react-native';
-import {useUpdateUserInfo} from '~/api/queries/auth';
-import {showToast} from '~/components/common/modal/toastConfig';
-import LoadingModal from '~/components/common/modal/LoadingModal';
+import UpdateProfile from '~/components/setting/UpdateProfile';
 
 const EditProfileScreen = () => {
-  const navigation = useNavigation<RootStackNavigationProp>();
   const userInfo = useUserInfo();
-  const [art, setArt] = useState<string>(userInfo.favoriteArt);
-  const [nicknameKeyword, setNicknameKeyword] = useState<string>(
-    userInfo.nickname,
-  );
-  const [imageUri, setImageUri] = useState<string | undefined>(
-    `data:image/png;base64,${userInfo.profile}`,
-  );
-  const [isLoadingOpen, setIsLoadingOpen] = useState<boolean>(false);
-  const [createFormData, setCreateFormData] = useState<FormData | null>(null);
-  const {
-    mutate: updateUserInfo,
-    isLoading,
-    isError,
-    isSuccess,
-  } = useUpdateUserInfo(createFormData);
-
-  useEffect(() => {
-    if (createFormData !== null) {
-      updateUserInfo();
-    }
-  }, [createFormData]);
-
-  useEffect(() => {
-    if (isError) {
-      showToast('정보 수정을 실패했습니다.');
-    }
-    if (isLoading) {
-      setIsLoadingOpen(true);
-    }
-    if (!isLoading) {
-      setIsLoadingOpen(false);
-    }
-    if (isSuccess) {
-      setCreateFormData(null);
-      showToast('정보 수정 완료!');
-      navigation.goBack();
-    }
-  }, [isError, isLoading, isSuccess]);
-
-  const onPressComplete = async () => {
-    const formData = new FormData();
-
-    formData.append('nickname', nicknameKeyword);
-    formData.append('favoriteArt', art);
-
-    const isImage = imageUri?.search('file://');
-    if (isImage && isImage !== -1) {
-      const resizedImage = await ImageResizer.createResizedImage(
-        imageUri ?? '', // path
-        300, // width
-        300, // height
-        'JPEG', // format
-        100, // quality
-        undefined, // rotation
-        // uploadFileName, // outputPath
-        undefined, // keepMeta,
-        undefined, // options => object
-      );
-      const uri = resizedImage.uri;
-      const filename = uri.split('/').pop();
-      const match = /\.(\w+)$/.exec(filename || '');
-      const type = match ? `image/${match[1]}` : `image`;
-
-      formData.append('profile', {
-        name: filename,
-        type,
-        uri: uri,
-      });
-    }
-    setCreateFormData(formData);
-  };
 
   return (
-    <Container>
-      <BackView title="프로필 수정" line={true} />
-
-      {/* body */}
-      <Contents>
-        {/* 닉네임 */}
-        <EditNickname
-          getNickname={nicknameKeyword}
-          setNickname={setNicknameKeyword}
-        />
-        {/* 좋아하는 전시 분야 */}
-        <EditArtCategory getValue={art} setValue={setArt} />
-        {/* 프로필 */}
-        <EditPicture imageUri={imageUri} setImageUri={setImageUri} />
-        {/* 이메일 */}
-        <ContentColumn>
-          <SectionName>이메일</SectionName>
-          <BoxView color={true}>
-            {userInfo.email.includes('naver') ? (
-              <NaverIcon width={20} />
-            ) : userInfo.email.includes('gmail') ? (
-              <GoogleIcon width={20} />
-            ) : (
-              <KakaoIcon width={20} />
-            )}
-            <EmailText>{userInfo.email}</EmailText>
-          </BoxView>
-        </ContentColumn>
-        {/* 완료 버튼 */}
-        <TouchableOpacity onPress={onPressComplete}>
-          <CompleteButton moveNext={true}>완료</CompleteButton>
-        </TouchableOpacity>
-      </Contents>
-      {isLoadingOpen && <LoadingModal message={'정보 수정 중 :)'} />}
-    </Container>
+    <UpdateProfile
+      title={'프로필 수정'}
+      initProfile={{
+        favoriteArt: userInfo.favoriteArt,
+        nickname: userInfo.nickname,
+        profile: userInfo.profile,
+        email: userInfo.email,
+        providerType: userInfo.email.split('@')[1].split('.')[0],
+      }}
+      messages={{
+        errorMsg: '정보 수정을 실패했습니다.',
+        successMsg: '정보 수정 완료!',
+      }}
+      navigateTo={'back'}
+    />
   );
 };
 
 export default EditProfileScreen;
-
-/** style */
-const Container = styled.View`
-  flex: 1;
-`;
-
-const Contents = styled.View`
-  flex: 1;
-  width: 100%;
-  height: 100%;
-  flex-direction: column;
-  background-color: #f6f6f6;
-  padding-left: ${wp(15)}px;
-  padding-right: ${wp(15)}px;
-  padding-top: ${hp(10)}px;
-  padding-bottom: ${hp(10)}px;
-  gap: ${hp(15)}px;
-`;
-
-const ContentColumn = styled.View`
-  flex-direction: column;
-  width: 100%;
-  gap: ${hp(10)}px;
-`;
-
-const SectionName = styled.Text`
-  font-size: ${fp(19)}px;
-  color: #3c4045;
-  font-family: 'omyu pretty';
-`;
-
-interface ContentProps {
-  color: boolean;
-}
-
-const BoxView = styled.View<ContentProps>`
-  border-width: 1.5px;
-  border-color: #d3d3d3;
-  border-radius: 10px;
-  flex-direction: row;
-  background-color: ${(props: ContentProps) =>
-    props.color ? '#d9d9d9' : '#f6f6f6'};
-  padding: ${hp(10)}px;
-  gap: 6.5px;
-  align-items: center;
-`;
-
-const EmailText = styled.Text`
-  font-size: ${fp(18)}px;
-  color: white;
-  font-family: 'omyu pretty';
-  text-align: center;
-`;
-
-interface NextButtonProps {
-  complete: boolean;
-}
-
-const CompleteButton = styled.Text<NextButtonProps>`
-  padding: ${hp(10)}px;
-  border-radius: 5px;
-  text-align: center;
-  background-color: #ff6f61;
-  /* background-color: ${(props: NextButtonProps) =>
-    props.complete ? '#ff6f61' : '#D3D3D3'}; */
-  color: white;
-  font-size: ${fp(17)}px;
-  font-family: 'omyu pretty';
-`;

--- a/src/utils/CheckKeyword.ts
+++ b/src/utils/CheckKeyword.ts
@@ -1,0 +1,10 @@
+export const checkBlankInKeyword = (text: string): boolean => {
+  var blank = false;
+  if (text === '') {
+    blank = true;
+  }
+  if (text.trim() === '') {
+    blank = true;
+  }
+  return blank;
+};


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #124 
<br/>

## ⚙️ 변경 사항 

검색 키워드 빈 문자열 검사 공통 함수 분리 & 사용자 정보 수정 공통 컴포넌트 분리

- 검색 키워드 빈 문자열 검사 공통 함수 분리
- 사용자 정보 수정 공통 컴포넌트 분리
- 탈퇴 후 로그인 화면으로 이동
- 사용자 정보 수정 중 닉네임 작성 칸에 빈 문자열이 있을 경우 중복 확인이 되지 않도록 수정

<br/>

## 💦 변경한 이유

- 여러 컴포넌트에서 사용하는 빈 문자열 검사 함수가 같기 때문에 공통으로 사용할 수 있도록 util 경로에 파일 생성
- 두 개의 사용자 정보 수정 컴포넌트의 형식이 같기 때문에 공통 컴포넌트 분리
- 로그인 화면 구현 완료로 탈퇴 후 로그인 화면으로 이동이 가능해짐
- 사용자 정보 수정 중 닉네임 작성 칸에 빈 문자열이 있을 때 중복 확인 버튼을 누르면 불필요한 api 요청이 생기는 것을 해결

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
