### PR TITLE
[refactor] 전시회 상세 페이지에서 캘린더 이동 해결

### DIFF
--- a/src/assets/images/index.ts
+++ b/src/assets/images/index.ts
@@ -1,6 +1,6 @@
 // bottom nav icon
-export {default as OffCalender} from './bottom_nav_icon/off_calendar.svg';
-export {default as OnCalender} from './bottom_nav_icon/on_calendar.svg';
+export {default as OffCalendar} from './bottom_nav_icon/off_calendar.svg';
+export {default as OnCalendar} from './bottom_nav_icon/on_calendar.svg';
 export {default as OffMate} from './bottom_nav_icon/off_mate.svg';
 export {default as OnMate} from './bottom_nav_icon/on_mate.svg';
 export {default as OffSetting} from './bottom_nav_icon/off_setting.svg';

--- a/src/components/common/CustomCalendar.tsx
+++ b/src/components/common/CustomCalendar.tsx
@@ -7,7 +7,7 @@ import {
   heightSizePercentage as hp,
   widthSizePercentage as wp,
 } from '~/components/common/ResponsiveSize';
-import {dateToString} from '~/utils/Date';
+import {dateToString, JoinDateWithDot} from '~/utils/Date';
 import {DEFAULT_TEXT, MAIN_COLOR} from './colors';
 import {FONT_NAME, ITEM_BORDER_WIDTH} from './style';
 
@@ -17,6 +17,7 @@ interface MarkedType {
 }
 
 interface CalendarProps {
+  initDate: number[];
   onSelectedDate: (selectedDate: string) => void;
   markedDates: MarkedType[];
   setChangeMonth?: (changeMonth: string) => void;
@@ -46,14 +47,17 @@ const months = [
 ];
 
 const CustomCalendar: React.FC<CalendarProps> = ({
+  initDate,
   onSelectedDate,
   markedDates,
   setChangeMonth,
   children,
 }) => {
-  const [currentDate, setCurrentDate] = useState(new Date()); // 현재 월
+  const [currentDate, setCurrentDate] = useState<Date>(
+    new Date(initDate[0], initDate[1] - 1, initDate[2]),
+  ); // 현재 월
   const [selectedDate, setSelectedDate] = useState<string>(
-    dateToString(new Date()),
+    JoinDateWithDot(initDate),
   ); // 선택한 날짜
 
   const goToNextMonth = () => {

--- a/src/components/common/icon.tsx
+++ b/src/components/common/icon.tsx
@@ -19,11 +19,11 @@ import {
   LeaveGathering,
   MoreContents,
   NaverLogo,
-  OffCalender,
+  OffCalendar,
   OffExhibition,
   OffMate,
   OffSetting,
-  OnCalender,
+  OnCalendar,
   OnExhibition,
   OnMate,
   OnSetting,
@@ -198,14 +198,14 @@ export const CameraButtonIcon = () => {
 };
 
 /** bottom nav */
-export const OffCalenderIcon = () => {
+export const OffCalendarIcon = () => {
   const height = hp(5);
-  return <OffCalender width={100 * (height / 153)} height={height} />;
+  return <OffCalendar width={100 * (height / 153)} height={height} />;
 };
 
-export const OnCalenderIcon = () => {
+export const OnCalendarIcon = () => {
   const height = hp(5);
-  return <OnCalender width={101 * (height / 153)} height={height} />;
+  return <OnCalendar width={101 * (height / 153)} height={height} />;
 };
 
 export const OffMateIcon = () => {

--- a/src/components/diary/AddVisitDate.tsx
+++ b/src/components/diary/AddVisitDate.tsx
@@ -15,6 +15,8 @@ import {
   FONT_NAME,
 } from '../common/style';
 import {DEFAULT_TEXT, LIGHT_GREY, MAIN_COLOR} from '../common/colors';
+import {splitDate} from '~/utils/Date';
+import {useDateFromExhInfo} from '~/zustand/calendar/dateFromExh';
 
 interface MarkedType {
   date: string;
@@ -38,6 +40,7 @@ const AddVisitDate: React.FC<AddVisitDateProps> = ({
   children,
   selectedMssg,
 }) => {
+  const {date: dateFromExhInfo} = useDateFromExhInfo();
   const alreadyMarkedDate = () => {
     for (var marked = 0; marked < markedDates.length; marked++) {
       if (markedDates[marked].date === selectedDate) {
@@ -53,6 +56,7 @@ const AddVisitDate: React.FC<AddVisitDateProps> = ({
       <GroupText>방문 날짜 선택</GroupText>
       {/* 커스텀 캘린더 */}
       <CustomCalendar
+        initDate={splitDate(dateFromExhInfo)}
         onSelectedDate={onSelectedDate}
         markedDates={markedDates}
       />

--- a/src/routes/BottomRoutes.tsx
+++ b/src/routes/BottomRoutes.tsx
@@ -19,11 +19,11 @@ import {BACK_COLOR, BORDER_COLOR} from '~/components/common/colors';
 import {showToast} from '~/components/common/modal/toastConfig';
 import {
   CenterDiaryIcon,
-  OffCalenderIcon,
+  OffCalendarIcon,
   OffExhibitionIcon,
   OffMateIcon,
   OffSettingIcon,
-  OnCalenderIcon,
+  OnCalendarIcon,
   OnExhibitionIcon,
   OnMateIcon,
   OnSettingIcon,
@@ -100,8 +100,8 @@ const BottomRoutes = () => {
               ) : (
                 <OffExhibitionIcon />
               );
-            } else if (route.name === 'Calender') {
-              iconSource = focused ? <OnCalenderIcon /> : <OffCalenderIcon />;
+            } else if (route.name === 'Calendar') {
+              iconSource = focused ? <OnCalendarIcon /> : <OffCalendarIcon />;
             } else if (route.name === 'Diary') {
               iconSource = <CenterDiaryIcon />;
             } else if (route.name === 'Mate') {
@@ -117,7 +117,7 @@ const BottomRoutes = () => {
         })}
         backBehavior="none">
         <Tab.Screen name="Exhibition" component={ExhListScreen} />
-        <Tab.Screen name="Calender" component={CalendarScreen} />
+        <Tab.Screen name="Calendar" component={CalendarScreen} />
         <Tab.Screen name="Diary" component={MyExhListScreen} />
         <Tab.Screen name="Mate" component={MateMainScreen} />
         <Tab.Screen name="Setting" component={SettingScreen} />

--- a/src/screens/calendar/CalendarScreen.tsx
+++ b/src/screens/calendar/CalendarScreen.tsx
@@ -1,7 +1,7 @@
 import React, {useEffect, useState} from 'react';
 import styled from 'styled-components/native';
 import CustomCalendar from '~/components/common/CustomCalendar';
-import {JoinDateWithDot, dateToString} from '~/utils/Date';
+import {JoinDateWithDot, splitDate} from '~/utils/Date';
 import {calendarColor} from './calendarColor';
 import {
   useTabIdentifierActions,
@@ -14,6 +14,7 @@ import {useFetchCalendar} from '~/api/queries/calendar';
 import LoadingModal from '~/components/common/modal/LoadingModal';
 import {showToast} from '~/components/common/modal/toastConfig';
 import {BACK_COLOR} from '~/components/common/colors';
+import {useDateFromExhInfo} from '~/zustand/calendar/dateFromExh';
 
 export interface IPicker {
   label: string;
@@ -30,10 +31,15 @@ const CalendarScreen = () => {
   const isFocused = useIsFocused();
   const tabIdentifierInfo = useTabIdentifierInfo();
   const {updateTab} = useTabIdentifierActions();
+  const {date: dateFromExhInfo} = useDateFromExhInfo();
   // 사용자가 선택한 날짜
-  const [selectedDate, setSelectedDate] = useState(dateToString(new Date()));
+  const [selectedDate, setSelectedDate] = useState(
+    JoinDateWithDot(splitDate(dateFromExhInfo)),
+  );
   // 월 변경 화살표 클릭 인식을 위한 상태 변화
-  const [changeMonth, setChangeMonth] = useState(dateToString(new Date()));
+  const [changeMonth, setChangeMonth] = useState(
+    JoinDateWithDot(splitDate(dateFromExhInfo)),
+  );
   // 일정이 있는 날짜 리스트
   const [markedDates, setMarkedDates] = useState<MarkedType[]>([]);
   // 모임 선택 selector - item
@@ -131,6 +137,7 @@ const CalendarScreen = () => {
   return (
     <Container>
       <CustomCalendar
+        initDate={splitDate(dateFromExhInfo)}
         onSelectedDate={setSelectedDate}
         markedDates={markedDates}
         setChangeMonth={setChangeMonth}>

--- a/src/screens/exhibition/ExhListScreen.tsx
+++ b/src/screens/exhibition/ExhListScreen.tsx
@@ -39,6 +39,7 @@ import {
 } from '~/components/common/icon';
 import {BACK_COLOR, BORDER_COLOR, MAIN_COLOR} from '~/components/common/colors';
 import {DASH_WIDTH, FONT_NAME} from '~/components/common/style';
+import {useDateFromExhActions} from '~/zustand/calendar/dateFromExh';
 
 interface Exhibition {
   exhId: number;
@@ -77,6 +78,7 @@ const ExhListScreen = () => {
   const {updateAddDate} = useAddScheduleActions();
   const tabIdentifierInfo = useTabIdentifierInfo();
   const {updateTab} = useTabIdentifierActions();
+  const {updateDate} = useDateFromExhActions();
 
   const {data, isLoading, isError, isSuccess, refetch} = useFetchSearchExh(
     selectedName,
@@ -114,6 +116,11 @@ const ExhListScreen = () => {
       setIsPriceVisible(false);
       setIsStateVisible(false);
       setIsDateVisible(false);
+
+      if (tabIdentifierInfo.tab !== 'exhibition') {
+        updateTab('exhibition');
+        updateDate(null);
+      }
 
       refetch();
     }
@@ -209,16 +216,7 @@ const ExhListScreen = () => {
   useEffect(() => {
     if (isSuccess) {
       setHearts(data);
-      // }
-
-      // useEffect(() => {
-      //   if (isFocused) {
-      if (tabIdentifierInfo.tab !== 'exhibition') {
-        updateTab('exhibition');
-      }
-      // refetch();
     }
-    // }, [isFocused, changeMonth, selectedValue]);
   }, [isSuccess, data]);
 
   useEffect(() => {

--- a/src/screens/exhibition/ExhSearchByDate.tsx
+++ b/src/screens/exhibition/ExhSearchByDate.tsx
@@ -3,7 +3,7 @@ import {widthSizePercentage as wp} from '~/components/common/ResponsiveSize';
 import React, {useState} from 'react';
 import styled from 'styled-components/native';
 import CustomCalendar from '~/components/common/CustomCalendar';
-import {changeDotToHyphen, dateToString} from '~/utils/Date';
+import {changeDotToHyphen, dateToString, splitDate} from '~/utils/Date';
 import {
   AREA_FONT_SIZE,
   BUTTON_FONT_SIZE,
@@ -13,6 +13,7 @@ import {
 } from '~/components/common/style';
 import {BACK_COLOR, DEFAULT_TEXT, MAIN_COLOR} from '~/components/common/colors';
 import {BackButtonIcon} from '~/components/common/icon';
+import {useDateFromExhInfo} from '~/zustand/calendar/dateFromExh';
 
 interface ExhSearchByDateProps {
   isVisible: boolean;
@@ -38,6 +39,7 @@ const ExhSearchByDate: React.FC<ExhSearchByDateProps> = ({
     state,
   );
   const [selectedOption5, setSelectedOption5] = useState<string | null>(date);
+  const {date: dateFromExhInfo} = useDateFromExhInfo();
 
   const onPressDate = (selectedOption4: string[] | null) => {
     const dateObject = changeDotToHyphen(selectedDate);
@@ -57,6 +59,7 @@ const ExhSearchByDate: React.FC<ExhSearchByDateProps> = ({
         <ContentView>
           <TextView>{'날짜 선택'}</TextView>
           <CustomCalendar
+            initDate={splitDate(dateFromExhInfo)}
             onSelectedDate={setSelectedDate}
             markedDates={[]}
             setChangeMonth={setChangeMonth}

--- a/src/screens/exhibition/ExhToCal.tsx
+++ b/src/screens/exhibition/ExhToCal.tsx
@@ -1,4 +1,4 @@
-import {useNavigation, RouteProp} from '@react-navigation/native';
+import {useNavigation, RouteProp, useIsFocused} from '@react-navigation/native';
 import React, {useEffect, useState} from 'react';
 import styled from 'styled-components/native';
 import {RootStackNavigationProp} from '~/App';
@@ -13,6 +13,7 @@ import {changeDotToHyphen, JoinDateWithDot, dateToString} from '~/utils/Date';
 import {calendarColor} from '~/screens/calendar/calendarColor';
 import OptionsModal from '~/components/exhibition/OptionsModal';
 import {BACK_COLOR} from '~/components/common/colors';
+import {useDateFromExhActions} from '~/zustand/calendar/dateFromExh';
 
 interface MarkedType {
   date: string;
@@ -30,8 +31,9 @@ interface Props {
 }
 /**
  * TODO
- * 캘린더 이동이 안됨.
- * 날짜 저장하고 바로 달력에 표시 안됨.
+ * [x] 캘린더 이동이 안됨.
+ * [x] 캘린더 이동 시 해당 달로 이동
+ * [x] 날짜 저장하고 바로 달력에 표시 안됨.
  */
 const ExhToCal: React.FC<Props> = ({route}) => {
   const {exhId} = route.params;
@@ -41,6 +43,8 @@ const ExhToCal: React.FC<Props> = ({route}) => {
   const visitedExhId = exhId;
   const [markedDates, setMarkedDates] = useState<string[]>([]);
   const [isModalOpen, setIsModalOpen] = useState<boolean>(false); //날짜 선택 누를 시,모달 오픈
+  const {updateDate} = useDateFromExhActions();
+  const isFocused = useIsFocused();
 
   const {
     data: dates,
@@ -59,6 +63,12 @@ const ExhToCal: React.FC<Props> = ({route}) => {
     visitedExhId,
     isForgot ? null : changeDotToHyphen(selectedDate),
   );
+
+  useEffect(() => {
+    if (isFocused) {
+      refetchDates();
+    }
+  }, [isFocused]);
 
   useEffect(() => {
     if (isDatesSuccess) {
@@ -113,6 +123,7 @@ const ExhToCal: React.FC<Props> = ({route}) => {
 
   const onPressYes = () => {
     optionsModalClose();
+    updateDate(selectedDate);
     navigation.reset({
       index: 0,
       routes: [

--- a/src/screens/mate/gathering/GatheringInfoScreen.tsx
+++ b/src/screens/mate/gathering/GatheringInfoScreen.tsx
@@ -46,6 +46,7 @@ import {
   FONT_NAME,
 } from '~/components/common/style';
 import {Shadow} from 'react-native-shadow-2';
+import {useDateFromExhActions} from '~/zustand/calendar/dateFromExh';
 
 interface ExhInfo {
   exhId: number;
@@ -77,11 +78,13 @@ const GatheringInfoScreen = () => {
     isError: deleteError,
     isSuccess: deleteSuccess,
   } = useDeleteGathering(enterGatheringInfo.gatherId);
+  const {updateDate} = useDateFromExhActions();
 
   useEffect(() => {
     if (isFocused) {
       if (tabIdentifierInfo.tab !== 'gathering') {
         updateTab('gathering');
+        updateDate(null);
       }
       refetch();
     }

--- a/src/screens/mate/main/MateMainScreen.tsx
+++ b/src/screens/mate/main/MateMainScreen.tsx
@@ -28,17 +28,20 @@ import {
   DASH_WIDTH,
   FONT_NAME,
 } from '~/components/common/style';
+import {useDateFromExhActions} from '~/zustand/calendar/dateFromExh';
 
 const MateMainScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const isFocused = useIsFocused();
   const tabIdentifierInfo = useTabIdentifierInfo();
   const {updateTab} = useTabIdentifierActions();
+  const {updateDate} = useDateFromExhActions();
 
   useEffect(() => {
     if (isFocused) {
       if (tabIdentifierInfo.tab !== 'mate') {
         updateTab('mate');
+        updateDate(null);
       }
     }
   }, [isFocused]);

--- a/src/screens/mydiary/MyExhListScreen.tsx
+++ b/src/screens/mydiary/MyExhListScreen.tsx
@@ -10,17 +10,20 @@ import {
   useTabIdentifierInfo,
 } from '~/zustand/tabIdentifier';
 import {AddMyExhButtonIcon} from '~/components/common/icon';
+import {useDateFromExhActions} from '~/zustand/calendar/dateFromExh';
 
 const MyExhListScreen = () => {
   const navigation = useNavigation<RootStackNavigationProp>();
   const isFocused = useIsFocused();
   const tabIdentifierInfo = useTabIdentifierInfo();
   const {updateTab} = useTabIdentifierActions();
+  const {updateDate} = useDateFromExhActions();
 
   useEffect(() => {
     if (isFocused) {
       if (tabIdentifierInfo.tab !== 'mydiary') {
         updateTab('mydiary');
+        updateDate(null);
       }
     }
   }, [isFocused]);

--- a/src/screens/setting/SettingScreen.tsx
+++ b/src/screens/setting/SettingScreen.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, {useEffect} from 'react';
 import styled from 'styled-components/native';
 import Header from '~/components/common/Header';
 import {
@@ -6,7 +6,7 @@ import {
   heightSizePercentage as hp,
   widthSizePercentage as wp,
 } from '~/components/common/ResponsiveSize';
-import {useNavigation} from '@react-navigation/native';
+import {useIsFocused, useNavigation} from '@react-navigation/native';
 import {RootStackNavigationProp} from '~/App';
 import ProfileNameTag from './nameTag/ProfileNameTag';
 import GreyNameTag from '../../components/common/GreyNameTag';
@@ -20,10 +20,28 @@ import {mydiaryQueryKeys} from '~/api/queries/mydiary';
 import {mateQueryKeys} from '~/api/queries/mate';
 import {AREA_FONT_SIZE, FONT_NAME} from '~/components/common/style';
 import {BACK_COLOR, DEFAULT_TEXT} from '~/components/common/colors';
+import {
+  useTabIdentifierActions,
+  useTabIdentifierInfo,
+} from '~/zustand/tabIdentifier';
+import {useDateFromExhActions} from '~/zustand/calendar/dateFromExh';
 
 const SettingScreen = () => {
   const queryClient = useQueryClient();
   const navigation = useNavigation<RootStackNavigationProp>();
+  const isFocused = useIsFocused();
+  const tabIdentifierInfo = useTabIdentifierInfo();
+  const {updateTab} = useTabIdentifierActions();
+  const {updateDate} = useDateFromExhActions();
+
+  useEffect(() => {
+    if (isFocused) {
+      if (tabIdentifierInfo.tab !== 'setting') {
+        updateTab('setting');
+        updateDate(null);
+      }
+    }
+  }, [isFocused]);
 
   const handleLogout = async () => {
     await AsyncStorage.removeItem('userId');

--- a/src/utils/Date.ts
+++ b/src/utils/Date.ts
@@ -32,6 +32,22 @@ export const changeDotToHyphen = (date: string) => {
   return date.replace(/\./g, '-');
 };
 
+export const splitDate = (date: string | null) => {
+  var data;
+  var result: number[] = [];
+
+  if (date) {
+    data = date.split('-');
+  } else {
+    data = dateToString(new Date()).split('.');
+  }
+
+  result.push(Number(data[0]));
+  result.push(Number(data[1]));
+  result.push(Number(data[2]));
+  return result;
+};
+
 export const getDateDay = (dates: number[]) => {
   const WEEKDAY = ['일', '월', '화', '수', '목', '금', '토'];
   return WEEKDAY[new Date(dates[0], dates[1] - 1, dates[2]).getDay()];

--- a/src/zustand/calendar/dateFromExh.ts
+++ b/src/zustand/calendar/dateFromExh.ts
@@ -1,0 +1,26 @@
+import {create} from 'zustand';
+import {changeDotToHyphen} from '~/utils/Date';
+
+// year.month.day
+interface DateFromExhState {
+  date: string | null;
+  actions: {
+    updateDate: (date: string | null) => void;
+  };
+}
+
+// create: 보관함(Store)을 만들어주는 유용한 함수
+const useDateFromExh = create<DateFromExhState>(set => ({
+  date: null,
+  actions: {
+    updateDate: (date: string | null) =>
+      set(state => ({date: date ? changeDotToHyphen(date) : date})),
+  },
+}));
+
+export const useDateFromExhInfo = () =>
+  useDateFromExh(state => ({
+    date: state.date,
+  }));
+export const useDateFromExhActions = () =>
+  useDateFromExh(state => state.actions);

--- a/src/zustand/tabIdentifier.ts
+++ b/src/zustand/tabIdentifier.ts
@@ -11,7 +11,13 @@ import {create} from 'zustand';
 //     params: undefined,
 //   });
 // };
-type TabName = 'mydiary' | 'calendar' | 'mate' | 'gathering' | 'exhibition';
+type TabName =
+  | 'mydiary'
+  | 'calendar'
+  | 'mate'
+  | 'gathering'
+  | 'exhibition'
+  | 'setting';
 
 /** 캘린더와 내 기록 구분 */
 interface TabIdentifierState {


### PR DESCRIPTION
## ✅ 풀_리퀘스트 체크리스트

- [x] commit message 가 적절한지 확인
- [x] 적절한 branch 로 요청했는지 확인
- [x] Assignees, Label 선택
<br/>
closed: #190 
<br/>

## ⚙️ 변경 사항 

전시회 상세 페이지에서 캘린더 이동 해결

- 캘린더 이동 안되는 문제
- 캘린더 이동 후 선택한 날짜 보여주기
- 날짜 선택 후 취소 눌렀다가 날짜 선택 페이지로 가면 바로 전에 선택한 날짜 표시되어 있지 않는 문제

<br/>

## 💦 변경한 이유

캘린더 이동 안되는 문제
- 스펠링 오타

캘린더 이동 후 선택한 날짜 보여주기
- customcalendar 컴포넌트에 props 추가

날짜 선택 후 취소 눌렀다가 날짜 선택 페이지로 가면 바로 전에 선택한 날짜 표시되어 있지 않는 문제
- useFocued 사용하여 방문 날짜 업데이트

<br/>

## 💻 테스트 사항

- 어떻게 테스트를 실행했는지 작성

<br/>

## ⚠️ 변경 및 주의 사항

<!--
변경사항 및 주의 사항이 작성
-->

<br/>
